### PR TITLE
Add purgecss rejected and rejectedCss properties support

### DIFF
--- a/purge.js
+++ b/purge.js
@@ -23,8 +23,14 @@ module.exports = async function purge(options = {}) {
 
   const result = await new PurgeCSS().purge(options.config);
 
-  for (const { file, css } of result) {
+  for (const { file, css, rejected, rejectedCss } of result) {
     log(`Writing ${file}`);
+    if (rejected && rejected.length) {
+      log(`Rejected: ${rejected.join(", ")}`);
+    }
+    if (rejectedCss) {
+      log(`Rejected CSS: ${rejectedCss}`);
+    }
     await fsWriteFile(file, css);
   }
 


### PR DESCRIPTION
Hello,

When using purgecss, it's possible to output which rules has been delected using `rejected` and/or `rejectedCss` properties.

https://purgecss.com/api-reference/purgecss.options.html

By logging the result if available, it helps developer to know what rule has deleted directly in elventy